### PR TITLE
cmake include path fixed to be a system include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set (CMAKE_CXX_STANDARD 11)
 # ------------------------------------------------------------------------------------------------------
 
 # set include/ as include directory
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # macro that adds a list of provided source files to a list called SRCS.
 # if variable SRCS does not yet exist, it is created.
@@ -116,7 +116,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/amqpcpp.pc.in"
                "${CMAKE_CURRENT_BINARY_DIR}/amqpcpp.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/amqpcpp.pc" DESTINATION lib/pkgconfig)
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
     $<INSTALL_INTERFACE:include/>
 )


### PR DESCRIPTION
This fixes the compilation issues, by making include paths SYSTEM, which prevents compiler from generating warnings in included files.